### PR TITLE
Logic bug fixed which caused applyContentFilter to trigger all the time

### DIFF
--- a/easy-table-of-contents.php
+++ b/easy-table-of-contents.php
@@ -536,7 +536,7 @@ if ( ! class_exists( 'ezTOC' ) ) {
 			// bail if post not eligible and widget is not active
 			$is_eligible = self::is_eligible();
 
-			if ( ! $is_eligible && ! is_active_widget( false, false, 'ezw_tco' ) ) {
+			if ( ! $is_eligible || ! is_active_widget( false, false, 'ezw_tco' ) ) {
 
 				return $content;
 			}


### PR DESCRIPTION
Corrected small error where plugin did its magic thru applyContentFilter on the post content even when the posttype was not eligible or the widget was inactive