### PR TITLE
Add `ez-toc-list` class to all lists

### DIFF
--- a/includes/class.post.php
+++ b/includes/class.post.php
@@ -1293,7 +1293,7 @@ class ezTOC_Post {
 					for ( $current_depth; $current_depth < (int) $matches[ $i ][2]; $current_depth++ ) {
 
 						$numbered_items[ $current_depth + 1 ] = 0;
-						$html .= '<ul class="ez-toc-list-level-' . $level . '"><li class="ez-toc-heading-level-' . $level . '">';
+						$html .= '<ul class="ez-toc-list ez-toc-list-level-' . $level . '"><li class="ez-toc-heading-level-' . $level . '">';
 					}
 				}
 


### PR DESCRIPTION
While first-level lists include a generic `.ez-toc-list` HTML class in addition to `.ez-toc-list-level-1`, nested lists only have a variable class name including the nesting level.
So if you want to apply styles to all lists regardless of their nesting level, you either have to use the tag selector (e.g. `#ez-toc-container ul`, which some might consider bad practice) or use an unnecessarily inconvenient attribute selector (`[class^="ez-toc-list"]`).

By adding a generic `.ez-toc-list` class to all lists, none of the "workarounds" would be necessary.