### PR TITLE
Add request url before anchor link

### DIFF
--- a/includes/class.options.php
+++ b/includes/class.options.php
@@ -542,6 +542,13 @@ if ( ! class_exists( 'ezTOC_Option' ) ) {
 							'type' => 'text',
 							'default' => '',
 						),
+						'add_request_uri' => array(
+							'id' => 'add_request_uri',
+							'name' => __( 'Add Request URI', 'easy-table-of-contents' ),
+							'desc' => __( 'Add request URI before anchor link. ', 'easy-table-of-contents' ) . __( 'Eg: href="/post/id#xxxx"', 'easy-table-of-contents' ),
+							'type' => 'checkbox',
+							'default' => 'false',
+						),
 					)
 				),
 			);

--- a/includes/class.post.php
+++ b/includes/class.post.php
@@ -1392,7 +1392,7 @@ class ezTOC_Post {
 
 		if ( $page === $current_page && $current_post ) {
 
-			return '#' . $id;
+			return (ezTOC_Option::get( 'add_request_uri' ) ? $_SERVER['REQUEST_URI'] : '') . '#' . $id;
 
 		} elseif ( 1 === $page ) {
 


### PR DESCRIPTION
My wordpress template contains a base tag in a head tag like bellow.
```
<base href="/">
```
This tag cases a problem in my anchor link, which links to the top url. So I added the request URI before the anchor.
