### PR TITLE
2.0.75

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Tags: table of contents, toc
 Requires at least: 5.0  
 Tested up to: 6.8  
 Requires PHP: 5.6.20  
-Stable tag: 2.0.74  
+Stable tag: 2.0.75 
 License: GPLv2 or later  
 License URI: https://www.gnu.org/licenses/gpl-2.0.html  
 

--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: table of contents, toc
 Requires at least: 5.0
 Tested up to: 6.8
 Requires PHP: 5.6.20
-Stable tag: 2.0.74
+Stable tag: 2.0.75
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -135,6 +135,14 @@ Easy Table Contents is a fork of the excellent [Table of Contents Plus](https://
 
 == Changelog ==
 
+= 2.0.75 30/06/2025 =
+* Bug: TOC is not working on ACF fields #878
+* Bug: Sticky TOC incorrectly adds 'ez-toc-section' span on Pages even when disabled for Page post type #884
+* Bug: Issue with Tasty recipe plugin #891
+* Bug : Error in recent update #886
+* Compatibility: Easy TOC not picking up heading in ACF flexible headings components #896
+* Improvement: option to hide the 'TOC' feature in the Classic Editor. #888
+
 = 2.0.74 05/05/2025 =
 * Bug: Accordion TOC disappears when clicking at the + / - icon #880
 * Bug: The post content is scrolled to the top while using Sticky Widget #879
@@ -242,18 +250,6 @@ Easy Table Contents is a fork of the excellent [Table of Contents Plus](https://
 * TWEAK: Warning: Undefined array key "s_blockqoute_checkbox" #728
 * TWEAK: Write plugin name in subject of feedback form #731
 * New: Added to exclude heading from query loop feature #730
-
-= 2.0.64 28/03/2024 =
-* TWEAK: When clicked on copy shortcode, Page is shaking #695
-* TWEAK: Uncaught ReferenceError #693
-* TWEAK: Need to correct [initial_view='no'] shortcode in TOC #715
-* New: Exclude By Matching Url/String Option is not working for Sticky TOC #688
-* New: Added a new feature to set different positions on specific posts/pages #697
-* New: Added a new feature to Filter/Hook for Adding Custom Links Before and After Toc plugin-generated Links #718
-* Bug: Fatal Error: [ez-toc-widget-sticky] Shortcode and also Conflict with 'Internal Link Juicer (Pro)'. #704
-* Bug: Sidebar’s PHP Error Notices in TOC version 2.0.63 #716
-* Bug: Double invoice showing when sitenavigation schema option enabled #720
-* Compatibility: Tested with Wordpress 6.5 #723
 
 
 Full changelog available at [changelog.txt](https://plugins.svn.wordpress.org/easy-table-of-contents/trunk/changelog.txt)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,13 @@
 == Changelog ==
 
+= 2.0.75 30/06/2025 =
+* Bug: TOC is not working on ACF fields #878
+* Bug: Sticky TOC incorrectly adds 'ez-toc-section' span on Pages even when disabled for Page post type #884
+* Bug: Issue with Tasty recipe plugin #891
+* Bug : Error in recent update #886
+* Compatibility: Easy TOC not picking up heading in ACF flexible headings components #896
+* Improvement: option to hide the 'TOC' feature in the Classic Editor. #888
+
 = 2.0.74 05/05/2025 =
 * Bug: Accordion TOC disappears when clicking at the + / - icon #880
 * Bug: The post content is scrolled to the top while using Sticky Widget #879

--- a/easy-table-of-contents.php
+++ b/easy-table-of-contents.php
@@ -3,7 +3,7 @@
  * Plugin Name: Easy Table of Contents
  * Plugin URI: https://tocwp.com/
  * Description: Adds a user friendly and fully automatic way to create and display a table of contents generated from the page content.
- * Version: 2.0.74
+ * Version: 2.0.75
  * Author: Magazine3
  * Author URI: https://tocwp.com/
  * Text Domain: easy-table-of-contents
@@ -28,7 +28,7 @@
  * @package  Easy Table of Contents
  * @category Plugin
  * @author   Magazine3
- * @version  2.0.74
+ * @version  2.0.75
  */
 
 use Easy_Plugins\Table_Of_Contents\Debug;
@@ -52,7 +52,7 @@ if ( ! class_exists( 'ezTOC' ) ) {
 		 * @since 1.0
 		 * @var string
 		 */
-		const VERSION = '2.0.74';
+		const VERSION = '2.0.75';
 
 		/**
 		 * Stores the instance of this class.

--- a/easy-table-of-contents.php
+++ b/easy-table-of-contents.php
@@ -1996,9 +1996,15 @@ if ( ! class_exists( 'ezTOC' ) ) {
 			   
 		
            if ( 'true' == get_user_option( 'rich_editing' ) ) {
-               add_filter( 'mce_external_plugins', array( __CLASS__, 'toc_add_tinymce_plugin'));
-               add_filter( 'mce_buttons', array( __CLASS__, 'toc_register_mce_button' ));
+			   $show_mce_button = true;
+			   if ( ! ezTOC_Option::get( 'show-toc-toolbar-classic', true ) ) {
+				   $show_mce_button = false;
+			   }
+			   if ( $show_mce_button ) {			
+				add_filter( 'mce_external_plugins', array( __CLASS__, 'toc_add_tinymce_plugin'));
+				add_filter( 'mce_buttons', array( __CLASS__, 'toc_register_mce_button' ));
                }
+			}
 			
 		}
 		

--- a/easy-table-of-contents.php
+++ b/easy-table-of-contents.php
@@ -1700,7 +1700,9 @@ if ( ! class_exists( 'ezTOC' ) ) {
 
 			Debug::log( 'post_eligible', 'Post eligible.', $isEligible );
 			$return_only_an = false; 
-			if(!$isEligible && (self::is_sidebar_hastoc() || is_active_widget( false, false, 'ezw_tco' ) || is_active_widget( false, false, 'ez_toc_widget_sticky' ) || ezTOC_Option::get('sticky-toggle') )){
+			$post_type = get_post_type( $ez_toc_current_post_id );
+			$sticky_enabled_on_post = in_array( $post_type, ezTOC_Option::get( 'sticky-post-types', array() ), true );
+			if(!$isEligible && (self::is_sidebar_hastoc() || is_active_widget( false, false, 'ezw_tco' ) || is_active_widget( false, false, 'ez_toc_widget_sticky' ) || ( ezTOC_Option::get('sticky-toggle') && $sticky_enabled_on_post ) )){
 				$isEligible = true;
 				$return_only_an = true;
 			}

--- a/includes/class-eztoc-option.php
+++ b/includes/class-eztoc-option.php
@@ -917,8 +917,8 @@ text
 						),
 						'show-toc-toolbar-classic' => array(
 							'id' => 'show-toc-toolbar-classic',
-							'name' => esc_html__( 'Show TOC in Toolbar of Classic Editor', 'easy-table-of-contents' ),
-							'desc' => esc_html__( 'This will display the TOC toolbar in the classic editor.', 'easy-table-of-contents' ),
+							'name' => esc_html__( 'Shortcode Button in TinyMCE', 'easy-table-of-contents' ),
+							'desc' => esc_html__( 'This will display the TOC shortcode button in toolbar of classic editor.', 'easy-table-of-contents' ),
 							'type' => 'checkbox',
 							'default' => true,
 						),

--- a/includes/class-eztoc-option.php
+++ b/includes/class-eztoc-option.php
@@ -915,6 +915,13 @@ text
 							'type' => 'checkbox',
 							'default' => false,
 						),
+						'show-toc-toolbar-classic' => array(
+							'id' => 'show-toc-toolbar-classic',
+							'name' => esc_html__( 'Show TOC in Toolbar of Classic Editor', 'easy-table-of-contents' ),
+							'desc' => esc_html__( 'This will display the TOC toolbar in the classic editor.', 'easy-table-of-contents' ),
+							'type' => 'checkbox',
+							'default' => true,
+						),
 					)
 				),
                 'shortcode' => apply_filters(
@@ -1772,6 +1779,7 @@ text
 				'generate_toc_link_ids'               => false,
 				'enable_memory_fix'					  => false,
 				'delete-data-on-uninstall'			  => false,
+				'show-toc-toolbar-classic'            => true,
 			);
 
 			return apply_filters( 'ez_toc_get_default_options', $defaults );

--- a/includes/class-eztoc-post.php
+++ b/includes/class-eztoc-post.php
@@ -111,7 +111,8 @@ class ezTOC_Post {
                 'social-pug/index.php',
 				'fusion-builder/fusion-builder.php',
 				'modern-footnotes/modern-footnotes.php',
-				'yet-another-stars-rating-premium/yet-another-stars-rating.php'
+				'yet-another-stars-rating-premium/yet-another-stars-rating.php',
+				'tasty-recipes/tasty-recipes.php'
             )
         );
 
@@ -1848,7 +1849,7 @@ class ezTOC_Post {
 
 		if(ezTOC_Option::get( 'disable_toc_links' ,false ) ){
 			return sprintf(
-				'<a class=" ez-toc-heading-' . $count . '" role="button" >%2$s</a>',
+				'<a class=" ez-toc-heading-' . $count . '" role="button" >%1$s</a>',
 				$title
 			);
 		}

--- a/includes/class-eztoc-widgetsticky.php
+++ b/includes/class-eztoc-widgetsticky.php
@@ -591,7 +591,7 @@ if ( ! class_exists ( 'ezTOC_WidgetSticky' ) )
                        style="width:100%;"/>
             </p>
             <div class="ez-toc-widget-appearance-title">
-                <input type="checkbox" class="ez_toc_widget_appearance_options" id="<?php echo esc_attr($this->get_field_id( 'appearance_options' )); ?>" name="<?php echo esc_attr($this->get_field_name( 'appearance_options' )); ?>"  data-check="<?php echo $instance[ 'appearance_options' ];?>" <?php if( 'on' === $instance[ 'appearance_options' ] ) { ?> checked="checked" <?php  } ?> value="on"/>
+                <input type="checkbox" class="ez_toc_widget_appearance_options" id="<?php echo esc_attr($this->get_field_id( 'appearance_options' )); ?>" name="<?php echo esc_attr($this->get_field_name( 'appearance_options' )); ?>"  data-check="<?php echo esc_attr( $instance[ 'appearance_options' ] );?>" <?php if( 'on' === $instance[ 'appearance_options' ] ) { ?> checked="checked" <?php  } ?> value="on"/>
                 <label for="<?php echo esc_attr($this->get_field_id( 'appearance_options' )); ?>"><?php esc_html_e ( 'Appearance', 'easy-table-of-contents' ); ?></label>
                 <div id="ez-toc-widget-options-container" class="ez-toc-widget-appearance-options-container">
                     <div class="ez-toc-widget-form-group">

--- a/includes/inc.functions.php
+++ b/includes/inc.functions.php
@@ -648,7 +648,7 @@ function ez_toc_wp_strip_all_tags( $text, $remove_breaks = false ) {
 			'',
 			sprintf(
 				/* translators: 1: The function name, 2: The argument number, 3: The argument name, 4: The expected type, 5: The provided type. */
-				__( 'Warning: %1$s expects parameter %2$s (%3$s) to be a %4$s, %5$s given.' ),
+				__( 'Warning: %1$s expects parameter %2$s (%3$s) to be a %4$s, %5$s given.', 'easy-table-of-contents' ),
 				__FUNCTION__,
 				'#1',
 				'$text',

--- a/includes/inc.plugin-compatibility.php
+++ b/includes/inc.plugin-compatibility.php
@@ -1326,7 +1326,7 @@ function ez_toc_js_to_footer_for_wpbakery_category() {
     if ($js_fallback_fix) {
         ?>
         <script id="eztoc-wpbakery-link-fix-fallback">
-            <?php echo $js_fallback_fix; //phpcs:ignore - Already escaped above ?>
+            <?php echo $js_fallback_fix; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Safe variable already escaped ?>
         </script>
         <?php
     }


### PR DESCRIPTION
= 2.0.75 30/06/2025 =
* Bug: TOC is not working on ACF fields #878
* Bug: Sticky TOC incorrectly adds 'ez-toc-section' span on Pages even when disabled for Page post type #884
* Bug: Issue with Tasty recipe plugin #891
* Bug : Error in recent update #886
* Compatibility: Easy TOC not picking up heading in ACF flexible headings components #896
* Improvement: option to hide the 'TOC' feature in the Classic Editor. #888