### PR TITLE
Fix [ez-toc] heading_levels and exclude being ignored when the TOC object is already cached

### DIFF
--- a/easy-table-of-contents.php
+++ b/easy-table-of-contents.php
@@ -1809,6 +1809,15 @@ if ( ! class_exists( 'ezTOC' ) ) {
 					update_post_meta( $post_id, '_ez-toc-heading-levels', $headings );
 				}
 																				
+				/*
+				 * self::$store may already hold this post, built with the global settings by an earlier
+				 * caller (e.g. the SiteNavigation schema output in wp_head on classic themes). That object
+				 * never saw the temporary post meta above, so drop it and rebuild.
+				 */
+				if ( ( isset( $atts['heading_levels'] ) && $atts['heading_levels'] != '' ) || ( isset( $atts['exclude'] ) && $atts['exclude'] != '' ) ) {
+					unset( self::$store[ $post_id ] );
+				}
+
 				$post = self::get( $post_id );
 
 				// setting original post meta for exclude and heading levels	


### PR DESCRIPTION
Fixes #979

## Problem

`ezTOC::shortcode()` applies `heading_levels` and `exclude` by temporarily writing them to post meta, calling `self::get( $post_id )`, and restoring the meta. `ezTOC::get()` returns a cached `ezTOC_Post` from `self::$store` when one exists, and heading levels and exclusions are read from post meta when the object is constructed. So if anything built the object before the shortcode ran, the temporary meta is never seen and both attributes are silently ignored.

Two ways that happens:

- On classic themes with "SiteNavigation Schema" enabled, `ez_toc_schema_sitenav_creator()` runs in `wp_head`, before the loop, and primes the cache with the global settings. Block themes render the template before `wp_head()`, which is why this does not reproduce on Twenty Twenty-Five.
- A second `[ez-toc]` on the same post with different attributes reuses the object built by the first one, on any theme.

## Fix

When either attribute is present, drop the cache entry before calling `self::get()`. The object is rebuilt with the temporary meta and stored as before, so `the_content` reuses the same object for the heading anchors and TOC links keep matching their targets.

The store itself and every other caller are untouched. The condition mirrors the existing `!= ''` checks so it only fires when the meta was actually written.

## Testing

Real page renders on a clean install (WP 7.1, PHP 8.4, plugin 2.0.87), post with 3 h2 + 4 h3 where the title "Overview" appears once as h3 and once as h2, global levels h2+h3.

Before, Twenty Twenty-One with schema on: `[ez-toc heading_levels="2"]` rendered 3 h2 + 4 h3. `[ez-toc exclude="*Beta*"]` removed nothing.

After:

- Twenty Twenty-One, schema on: `heading_levels="2"` renders 3 h2 + 0 h3; `exclude="*Beta*"` removes both Beta headings. Every TOC link resolves to the correct heading, including the duplicated "Overview".
- Twenty Twenty-One, schema off: unchanged from before the patch.
- Twenty Twenty-Five, schema on: unchanged from before the patch.
- Plain `[ez-toc]` with no attributes: byte-identical output, the cache is still used.
- Also verified on a production Genesis site with the original report's post (6 h2 + 10 h3): 6/10 before, 6/0 after.

I also tried building the object with `ezTOC_Post::get()` directly instead of evicting the cache. That fixed the counts but the TOC's h2 "Overview" link then pointed at the h3 "Overview", because collision suffixes are assigned after level filtering and `the_content` was still anchoring from the cached object. Evicting and rebuilding through `self::get()` avoids that.

Known limitation, unchanged in spirit: two `[ez-toc]` shortcodes with different filters on one post still share a single anchor set from whichever object is stored last, since the plugin keeps one object per post.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
