### PR TITLE
Guard nested the_content pass against core's _restore_wpautop_hook reentrancy

### DIFF
--- a/includes/class-eztoc-post.php
+++ b/includes/class-eztoc-post.php
@@ -281,11 +281,37 @@ class ezTOC_Post {
 		
 	}
 
-	// The ezTOC filter was removed above (line 220), so this is safe from infinite recursion
-	// Even if the_content triggers other filters, ezTOC::the_content won't be called again
-	$this->post->post_content = apply_filters( 'the_content', strip_shortcodes( $this->post->post_content ) ); //phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Using WP code hook
+	/*
+	 * Guard against a WordPress core reentrancy problem in do_blocks() / _restore_wpautop_hook().
+	 *
+	 * When this nested `the_content` pass runs from inside an outer `the_content` pass (the [ez-toc]
+	 * shortcode runs at priority 11) and the outer post contains blocks, core's do_blocks() has already
+	 * removed wpautop and queued `_restore_wpautop_hook` at priority 11. The nested pass would execute
+	 * and remove that pending callback, but WP_Hook still invokes the outer pass's copy afterwards;
+	 * `_restore_wpautop_hook()` then computes `false - 1` and registers wpautop at priority -1 for the
+	 * rest of the request. Every later the_content() call (reusable block areas, widgets, form output)
+	 * is then autop'd twice: once on raw block markup and once on rendered block output.
+	 *
+	 * Park the pending callback while the nested pass runs and put it back at the same priority so the
+	 * outer pass finishes exactly as core expects. No-op when not nested inside `the_content`.
+	 */
+	$restore_wpautop_priority = doing_filter( 'the_content' ) ? has_filter( 'the_content', '_restore_wpautop_hook' ) : false;
 
-	add_filter( 'the_content', array( 'ezTOC', 'the_content' ), 100 );  // increased  priority to fix other plugin filter overwriting our changes
+	if ( false !== $restore_wpautop_priority ) {
+		remove_filter( 'the_content', '_restore_wpautop_hook', $restore_wpautop_priority );
+	}
+
+	try {
+		// The ezTOC filter was removed above (line 220), so this is safe from infinite recursion
+		// Even if the_content triggers other filters, ezTOC::the_content won't be called again
+		$this->post->post_content = apply_filters( 'the_content', strip_shortcodes( $this->post->post_content ) ); //phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Using WP code hook
+	} finally {
+		if ( false !== $restore_wpautop_priority ) {
+			add_filter( 'the_content', '_restore_wpautop_hook', $restore_wpautop_priority );
+		}
+
+		add_filter( 'the_content', array( 'ezTOC', 'the_content' ), 100 );  // increased  priority to fix other plugin filter overwriting our changes
+	}
 
 		remove_filter( 'strip_shortcodes_tagnames', array( __CLASS__, 'stripShortcodes' ) );
 


### PR DESCRIPTION
Fixes #982

## Problem

When `[ez-toc]` runs from the `the_content` filter (priority 11) on a post that contains blocks, core has already done this at priority 9 in `do_blocks()`: removed `wpautop` and queued `_restore_wpautop_hook` at priority 11 to put it back.

`ezTOC_Post::applyContentFilter()` then applies `the_content` recursively to build the heading list. That nested pass runs the pending `_restore_wpautop_hook`, which removes itself. But `WP_Hook::apply_filters()` iterates over its own copy of the callback list, so the outer pass still calls `_restore_wpautop_hook` again. `has_filter()` now returns `false`, the function computes `false - 1`, and `wpautop` is registered at priority `-1` for the rest of the request.

From that point every later `the_content()` call on the page is autop'd twice: once on raw block markup at `-1`, again on rendered block output at `10`. Reusable block areas, widgets, Query Loop > Content, and form plugin output (Gravity Forms, WPForms, Fluent Forms) pick up stray `</p>`, empty paragraphs, and `<br />` after hidden inputs. The article and the TOC themselves look fine, which makes this hard to trace back to the shortcode.

The weak spot is core's restore hook (reported separately to Trac), but the plugin is the common trigger and can avoid it.

## Fix

In `applyContentFilter()`, if we are inside `the_content` and `_restore_wpautop_hook` is pending, remove it before the nested `apply_filters( 'the_content', ... )` and add it back at the same priority afterwards. The outer pass then completes exactly as core expects: `wpautop` is restored once, at priority 10.

The re-add and the existing re-registration of `ezTOC::the_content` sit in a `finally` block so hook state is restored even if a filter throws. The guard is a no-op when the TOC is built outside `the_content` (schema in `wp_head`, widgets, REST) because `has_filter()` returns `false` there.

## Testing

Real page renders on a clean install (WP 7.1, PHP 8.4) with a hook tracer logging the `the_content` callback list at every priority. Stock 2.0.87.1 versus this branch, same fixtures:

| Case | Stock 2.0.87.1 | This branch |
|---|---|---|
| Block post with `[ez-toc heading_levels="2"]`, form area after the article | `wpautop` at `-1` for the rest of the request; 7 stray `<br />` in the form | no `-1` entry; form byte-identical to the no-shortcode control |
| Two `[ez-toc]` shortcodes on one post | same damage | clean |
| WPForms block in the area | 3 stray `</p>` | clean |
| Twenty Twenty-Five single template with Query Loop > Content showing a WPForms post (repro from #982, no custom code) | damaged | clean |
| Post without `[ez-toc]`; classic (non-block) post | clean | clean, unchanged |

All of the above also pass with "SiteNavigation Schema" on and off, and on Twenty Twenty-One. The TOC output itself is unchanged in every case.

Interaction with #980: schema on a classic theme currently hides this bug only because the shortcode hits the TOC cache and skips the nested pass. #980 rebuilds the object when `heading_levels` or `exclude` is set, which brings the nested pass back. I verified this branch merged with #980 as well (schema on and off, all cases clean), so the two can land in either order but should ship together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UVoMNqAsqEAh7EWeFraZCX
